### PR TITLE
Fix /cgi-bin/ permanent redirect breaking POST requests

### DIFF
--- a/nginx/files-luci-support/luci.locations
+++ b/nginx/files-luci-support/luci.locations
@@ -12,6 +12,9 @@ location ~ /cgi-(backup|download|upload|exec) {
 		uwsgi_modifier1 9;
 		uwsgi_pass unix:////var/run/luci-cgi_io.socket;
 }
+location ~* ^/cgi-bin/(.*) {
+                return 307 $scheme://$http_host/$1$is_args$args;
+}
 
 location /luci-static {
 		error_log stderr crit;

--- a/nginx/files-luci-support/luci.locations
+++ b/nginx/files-luci-support/luci.locations
@@ -13,7 +13,7 @@ location ~ /cgi-(backup|download|upload|exec) {
 		uwsgi_pass unix:////var/run/luci-cgi_io.socket;
 }
 location ~* ^/cgi-bin/(.*) {
-                return 307 $scheme://$http_host/$1$is_args$args;
+		return 307 $scheme://$http_host/$1$is_args$args;
 }
 
 location /luci-static {


### PR DESCRIPTION
nginx/uci.conf rewrites /cgi-bin/* using 302 moved permanently, which will break POST requests (casuing browsers to use GET instead of POST) thus break scripts sending non-GET requests to /cgi-bin/ endpoints (e.g. linkease/istore).

This patch fixes the issue, and istore has been tested working correctly.